### PR TITLE
[feat] DataStore 를 사용해  조회한 캐릭터 식별자값을 로컬에 저장

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-    val properties = Properties()
-    properties.load(project.rootProject.file("local.properties").inputStream())
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
 
 
 
@@ -32,6 +32,8 @@ android {
     }
     buildFeatures {
         buildConfig = true
+        viewBinding = true
+        dataBinding = true
     }
 
 
@@ -51,8 +53,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-    viewBinding { enable = true }
-    dataBinding { enable = true }
+
 }
 
 dependencies {
@@ -66,13 +67,13 @@ dependencies {
     implementation("io.coil-kt:coil:2.5.0")
 
 
-    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1")
     //retrofit2(api호출라이브러리) = gson(json데이터를 코틀린 데이터클래스와 파싱해줌) + okhttp3 (통신용)
-    implementation ("com.google.code.gson:gson:2.10.1")
-    implementation ("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation ("com.squareup.retrofit2:converter-gson:2.9.0")
-    implementation ("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation ("com.squareup.okhttp3:logging-interceptor:4.10.0")
+    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
     //Data Store 라이브러리 추가
     // Preferences DataStore (SharedPreferences like APIs)
     implementation("androidx.datastore:datastore-preferences:1.0.0")
@@ -82,6 +83,9 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences-rxjava3:1.0.0")
     // Alternatively - use the following artifact without an Android dependency.
     implementation("androidx.datastore:datastore-preferences-core:1.0.0")
+    //lifecylce (viewmodel 사용에 필수)
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/android/maplemate/Data/MapleData.kt
+++ b/app/src/main/java/com/android/maplemate/Data/MapleData.kt
@@ -25,6 +25,11 @@ data class MapleData(
     val date: String?,
     @SerializedName("world_name")
     val worldName: String?,
-    val ocid: String,
-    val equipment: Equipment
+    @SerializedName("ocid")
+    val ocid: String?,
+    val equipment: Equipment?,
+    @SerializedName("union_grade")
+    val unionGrade: String?,
+    @SerializedName("union_level")
+    val unionLevel: Int?
 )

--- a/app/src/main/java/com/android/maplemate/Data/Union.kt
+++ b/app/src/main/java/com/android/maplemate/Data/Union.kt
@@ -1,0 +1,13 @@
+package com.android.maplemate.Data
+
+
+import com.google.gson.annotations.SerializedName
+
+data class Union(
+    @SerializedName("date")
+    val date: String?,
+    @SerializedName("union_grade")
+    val unionGrade: String?,
+    @SerializedName("union_level")
+    val unionLevel: Int?
+)

--- a/app/src/main/java/com/android/maplemate/MainActivity.kt
+++ b/app/src/main/java/com/android/maplemate/MainActivity.kt
@@ -4,17 +4,22 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.viewpager2.widget.ViewPager2
 import com.android.maplemate.databinding.ActivityMainBinding
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
-import java.util.prefs.Preferences
+
+
 
 class MainActivity : AppCompatActivity() {
 
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
     private val viewPagerAdapter by lazy { ViewPager2Adapter(this) }
+    //datastore 객체를 불러옴
+    private val Context.dataStore:
+            DataStore<Preferences> by preferencesDataStore( name = "getOcid" )
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val view = binding.root

--- a/app/src/main/java/com/android/maplemate/Repository/SecondFragmentRepository.kt
+++ b/app/src/main/java/com/android/maplemate/Repository/SecondFragmentRepository.kt
@@ -1,0 +1,9 @@
+package com.android.maplemate.Repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+
+class SecondFragmentRepository(
+    private val dataStore: DataStore<Preferences>
+) {
+}

--- a/app/src/main/java/com/android/maplemate/Service/ApiServiceMaple.kt
+++ b/app/src/main/java/com/android/maplemate/Service/ApiServiceMaple.kt
@@ -29,4 +29,13 @@ interface ApiServiceMaple {
         @Query("ocid") ocid: String,
         @Query("date") date: String
     ): Call<MapleData>
+
+    @GET("/maplestory/v1/user/union")
+    fun getUnion(
+        @Header("x-nxopen-api-key") apiKey: String,
+        @Query("ocid") ocid: String,
+        @Query("date") date: String
+    ): Call<MapleData>
+
+
 }

--- a/app/src/main/java/com/android/maplemate/UI/TestActivity.kt
+++ b/app/src/main/java/com/android/maplemate/UI/TestActivity.kt
@@ -3,7 +3,6 @@ package com.android.maplemate.UI
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -16,7 +15,6 @@ import com.android.maplemate.databinding.ActivityTestBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -29,6 +27,7 @@ class TestActivity : AppCompatActivity() {
     //datastore 객체를 불러옴
     private val Context.dataStore:
             DataStore<Preferences> by preferencesDataStore( name = "Ocid" )
+
     private lateinit var stringKey:String
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,7 +43,6 @@ class TestActivity : AppCompatActivity() {
                 stringKey = input
                 lifecycleScope.launch {
                     save(input)
-                    Toast.makeText(this@TestActivity, "저장된내용:${save(input)}", Toast.LENGTH_SHORT).show()
                 }
             } else {
                 Toast.makeText(this@TestActivity, "입력값이 비어있습니다.", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModel.kt
+++ b/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModel.kt
@@ -1,0 +1,13 @@
+package com.android.maplemate.ViewModel
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.ViewModel
+import com.android.maplemate.Repository.SecondFragmentRepository
+import com.android.maplemate.UI.SecondFragment
+
+class SecondFragmentViewModel(
+    private val dataStore: DataStore<Preferences>,
+    private val repository: SecondFragmentRepository
+):ViewModel() {
+}

--- a/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModelFactory.kt
+++ b/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.android.maplemate.ViewModel
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.android.maplemate.Repository.SecondFragmentRepository
+
+//class SecondFragmentViewModelFactory(private val dataStore: DataStore<Preferences>, private val repository: SecondFragmentRepository) : ViewModelProvider.Factory {
+//    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+//        if (modelClass.isAssignableFrom(SecondFragmentViewModel::class.java)) {
+//            return SecondFragmentViewModel(dataStore, repository) as T
+//        }
+//        throw IllegalArgumentException("Unknown ViewModel class")
+//    }
+//}

--- a/app/src/main/res/layout/fragment_second.xml
+++ b/app/src/main/res/layout/fragment_second.xml
@@ -14,7 +14,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:layout_marginTop="10dp"
-        android:visibility="gone">
+        android:visibility="visible">
         <ImageView
             android:id="@+id/iv_back_button"
             android:layout_width="wrap_content"
@@ -70,6 +70,12 @@
                 android:layout_height="wrap_content"
                 android:text="경험치"
                 android:textStyle="bold" />
+            <TextView
+                android:id="@+id/tv_union"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="유니온"
+                android:textStyle="bold"/>
 
         </LinearLayout>
 
@@ -81,7 +87,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:visibility="gone">
+        android:visibility="invisible">
 
         <EditText
             android:id="@+id/search_view"
@@ -102,54 +108,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="조회" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/blanc_yes_or_no"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:visibility="visible">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
             android:layout_marginTop="20dp"
-            android:text="김지성의 템을 훔쳐보시겠습니까?"
-            android:textStyle="bold" />
-
-        <LinearLayout
-            android:id="@+id/btn_box"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="70dp"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/btn_yes"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="110dp"
-                android:text="네" />
-
-            <Button
-                android:id="@+id/btn_no"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="10dp"
-                android:text="아니요" />
-        </LinearLayout>
-
+            android:text="조회" />
         <ImageView
             android:id="@+id/iv_background_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:src="@drawable/background"
             android:visibility="visible" />
-    </LinearLayout>
 
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
공식문서 가이드에 따라 SharedPreferences의 단점을 보완하기위해 나온 jetpack 라이브러리인 dataStore를 사용하였습니다.
함수는 모두 Corutine scope 안에서만 돌아갑니다. 이에따라 값을 저장하거나, 불러오는데 스레드 를 구분하여 변수를 초기화하는것이
중요합니다.  Corutine scope 안에서 쓰기,읽기 가 가능하기때문에 변수의 범위와 초기화하는 부분에 유의를 하여야합니다.

예를들어 String 타입의 변수를 지연초기화하고 프래그먼트의 onCreate 에서 초기화 한뒤, 최초 초기화된 변수가 참조되어 쓰기(저장) 읽기(불러오기) 에서 예상치 못한 상황이 발생할 수 있습니다.
Flow에서 데이터를 다루기때문에 scope에 유의하여  로직을 처리하는것이 좋습니다.

< 구조 >
dataStore를 사용해 Flow에  키=값 을 저장합니다. 
입력된 이름을 key, 입력된 이름을 기준으로 조회된 식별자값을 value 로하여  key = value 값 형태로 값을저장합니다.

<호출구조>
api 호출량 : -2
캐릭터명을 입력받고, 입력받은값으로 키값을 조회 -> 존재하지 않으면 mapleCall( 식별자를 찾는 Call객체 )을 부르고 네트워크 통신을하여
식별자값을 얻습니다. 
얻은 식별자값을 파라미터로 넣고 캐릭터 정보를 조회하는 characterCall을 부르고, response.body 의 객체를 꺼내 바인딩합니다.
api 호출량 : -1 
캐릭터명 입력받고, 입력받은값을 키값으로 하여 값이 존재하면 value(식별자값) 을 꺼내  파라미터로 대체합니다.

<img width="1180" alt="스크린샷 2024-01-06 오후 6 22 06" src="https://github.com/Retudy/Maplemate/assets/129308578/52e5f3f3-2173-4a20-8ffd-8461a4810acb">
