### PR TITLE
[fix] 임시 코드작성에서 characterCall객체를 두번 불러 동시에 Call객체가 호출되서 발생하는 오류 해결

### DIFF
--- a/app/src/main/java/com/android/maplemate/UI/SecondFragment.kt
+++ b/app/src/main/java/com/android/maplemate/UI/SecondFragment.kt
@@ -169,19 +169,21 @@ class SecondFragment : Fragment() {
                                 call.cancel()
                             }
                         })
-//                        characterCall.enqueue(object  : Callback<MapleData>{
-//                            override fun onResponse(
-//                                call: Call<MapleData>,
-//                                response: Response<MapleData>
-//                            ) {
-//                                val data = response.body()
-//
-//                            }
-//
-//                            override fun onFailure(call: Call<MapleData>, t: Throwable) {
-//                                call.cancel()
-//                            }
-//                        })
+                        UnionCall.enqueue(object  : Callback<MapleData>{
+                            override fun onResponse(
+                                call: Call<MapleData>,
+                                response: Response<MapleData>
+                            ) {
+                                val data = response.body()
+
+                                binding.tvUnion.text = "유니온:${data?.unionLevel}"
+
+                            }
+
+                            override fun onFailure(call: Call<MapleData>, t: Throwable) {
+                                call.cancel()
+                            }
+                        })
                     }
                 }}
             else{


### PR DESCRIPTION
코드 작성중에 팀원의 합류로 인해 임시코드를 merge 해서 생긴 오류였스빈다..