### PR TITLE
[fix] 잠재능력 1번 옵션이 없을때 에디셔널잠재능력만 안사라지는 버그 수정

### DIFF
--- a/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
+++ b/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
@@ -1,6 +1,7 @@
 package com.android.maplemate.Adapter
 
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,7 @@ import com.android.maplemate.databinding.FragmentSecondItemBinding
 
 class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
     RecyclerView.Adapter<SecondFragmentAdapter.ViewHolder>() {
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
@@ -39,21 +41,14 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
             binding.tvItemName.text = item?.itemName
             // 스타포스가 0 일때
             when(item?.starforce.toString()){
-                "0" -> binding.tvStarFoce.visibility = View.GONE
+                "0" -> binding.tvStarFoce.text = "⭐"
                 else -> binding.tvStarFoce.text = "⭐${item?.starforce}"
             }
             //옵션1 조건처리
 
             when(item?.potentialOption1.toString()) {
-//                "null" -> binding.tvPotentail.visibility = View.GONE
-//                "null" -> binding.tvAddPotential.visibility = View.GONE
-//                "null" -> binding.tvOption1.visibility = View.GONE
-//                "null" -> binding.tvOption2.visibility = View.GONE
-//                "null" -> binding.tvOption3.visibility = View.GONE
-                    "null" -> binding.framePotential.visibility = View.GONE
-                    "null" -> binding.frameAddPotential.visibility = View.GONE
 
-
+                 "null" -> binding.framePotential.visibility = View.GONE
                 "크리티컬 데미지 : +8%" -> binding.tvOption1.text = "크뎀 8%"
                 "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸샾>"
                 "<쓸만한 윈드 부스터> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸윈부>"
@@ -74,6 +69,12 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "HP 회복 아이템 및 회복 스킬 효율 : +30%" -> binding.tvOption1.text = "기타"
                 "4초 당 22의 MP 회복" -> binding.tvOption1.text = "기타"
                 else -> binding.tvOption1.text = item?.potentialOption1
+            }
+
+            var add = binding.framePotential.visibility
+
+            when (add){
+               View.GONE -> binding.frameAddPotential.visibility = View.GONE
             }
 
 
@@ -101,6 +102,7 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "4초 당 22의 MP 회복" -> binding.tvOption2.text = "기타"
                 else -> binding.tvOption2.text = item?.potentialOption2
             }
+
 
             //옵션3 조건처리
             when(item?.potentialOption3.toString()) {

--- a/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
+++ b/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
@@ -40,7 +40,7 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
             // 스타포스가 0 일때
             when(item?.starforce.toString()){
                 "0" -> binding.tvStarFoce.visibility = View.GONE
-                else -> binding.tvStarFoce.text = "${item?.starforce}성"
+                else -> binding.tvStarFoce.text = "⭐${item?.starforce}"
             }
             //옵션1 조건처리
 
@@ -80,7 +80,7 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
             //옵션2 조건처리
             when(item?.potentialOption2.toString()) {
                 "크리티컬 데미지 : +8%" -> binding.tvOption2.text = "크뎀 8%"
-                "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption2.text ="쓸샾⭐️"
+                "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption2.text ="쓸샾⭐"
                 "<쓸만한 윈드 부스터> 스킬 사용 가능" -> binding.tvOption2.text ="쓸윈부🌪️"
                 "보스 몬스터 공격 시 데미지 : +40%" -> binding.tvOption2.text = "보공40%"
                 "보스 몬스터 공격 시 데미지 : +35%" -> binding.tvOption2.text = "보공35%"


### PR DESCRIPTION
기
<img width="596" alt="스크린샷 2024-01-13 오후 10 03 17" src="https://github.com/Retudy/Maplemate/assets/129308578/f24cb635-05ca-41b9-bec1-d81465a036d2">
<img width="426" alt="스크린샷 2024-01-13 오후 10 02 57" src="https://github.com/Retudy/Maplemate/assets/129308578/361dd03d-9e2c-4e33-91a9-9f96fe5a0ccb">

기존에 잠재능력의 1번옵션이 null 일 경우에 잠재능력,에디셔널 잠재능력 옵션을 View.GONE 처리하였습니다.
같은 조건으로 두개의 로직을 실행해 잠재능력만 사라지고 에디셔널옵션은 사라지지않았던문제.


해결방안 1. 잠재,에디 레이아웃위에 다른 레이아웃 박스를 만들어줌
해결방안 2. 잠재능력 textView가 사라질경우. 에디셔널 잠재능력 text layout을 삭제하도록 조건 추가

xml이 여러겹의 LinearLayout으로 되어있기때문에 가독성이 매우 안좋은 상태라 최대한 뷰마다 독립적인 기능을 담당하게 하고자
2번으로 진행했습니다
