### PR TITLE
[bugfix] 다른 리스트의 View가 사라지는 현상 해결

### DIFF
--- a/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
+++ b/app/src/main/java/com/android/maplemate/Adapter/SecondFragmentAdapter.kt
@@ -54,46 +54,52 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
             }
             //옵션1 조건처리
 
-            when(item?.potentialOption1.toString()) {
+            when(item?.potentialOption1) {
 
-                "크리티컬 데미지 : +8%" -> binding.tvOption1.text = "크뎀 8%"
-                "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸샾>"
-                "<쓸만한 윈드 부스터> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸윈부>"
-                "보스 몬스터 공격 시 데미지 : +40%" -> binding.tvOption1.text = "보공40%"
-                "보스 몬스터 공격 시 데미지 : +35%" -> binding.tvOption1.text = "보공35%"
-                "보스 몬스터 공격 시 데미지 : +30%" -> binding.tvOption1.text = "보공30%"
-                "몬스터 방어율 무시 : +40%" -> binding.tvOption1.text = "방무40%"
-                "몬스터 방어율 무시 : +35%" -> binding.tvOption1.text = "방무35%"
-                "몬스터 방어율 무시 : +30%" -> binding.tvOption1.text = "방무30%"
-                "몬스터 방어율 무시 : +15%" -> binding.tvOption1.text = "방무15%"
-                "모든 스킬의 재사용 대기시간 : -2초(10초 이하는 10%감소, 5초 미만으로 감소 불가)" -> binding.tvOption1.text = "쿨감-2초"
-                "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvOption1.text = "쿨감-1초"
-                "아이템 드롭률 : +20%" -> binding.tvOption1.text = "드랍 20%"
-                "메소 획득량 : +20%" -> binding.tvOption1.text ="메획 20%"
-                "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvOption1.text ="렙당STR:+2"
-                "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvOption1.text ="렙당DEX:+2"
-                "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvOption1.text ="렙당INT:+2"
-                "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvOption1.text ="렙당LUK:+2"
-                "HP 회복 아이템 및 회복 스킬 효율 : +30%" -> binding.tvOption1.text = "기타"
-                "4초 당 22의 MP 회복" -> binding.tvOption1.text = "기타 ♻️"
-                "공격 시 10% 확률로 5레벨 중독효과 적용" -> binding.tvOption1.text = "기타 ♻️"
-                "30% 확률로 받은 피해의 70%를 반사" -> binding.tvOption3.text = "기타 ♻️"
+                null -> binding.framePotential.visibility = View.GONE
+                else -> { binding.framePotential.visibility = View.VISIBLE
 
-                else -> binding.tvOption1.text = item?.potentialOption1
+                    when(item?.potentialOption1){
 
-            }
+                        "크리티컬 데미지 : +8%" -> binding.tvOption1.text = "크뎀 8%"
+                        "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸샾>"
+                        "<쓸만한 윈드 부스터> 스킬 사용 가능" -> binding.tvOption1.text ="<쓸윈부>"
+                        "보스 몬스터 공격 시 데미지 : +40%" -> binding.tvOption1.text = "보공40%"
+                        "보스 몬스터 공격 시 데미지 : +35%" -> binding.tvOption1.text = "보공35%"
+                        "보스 몬스터 공격 시 데미지 : +30%" -> binding.tvOption1.text = "보공30%"
+                        "몬스터 방어율 무시 : +40%" -> binding.tvOption1.text = "방무40%"
+                        "몬스터 방어율 무시 : +35%" -> binding.tvOption1.text = "방무35%"
+                        "몬스터 방어율 무시 : +30%" -> binding.tvOption1.text = "방무30%"
+                        "몬스터 방어율 무시 : +15%" -> binding.tvOption1.text = "방무15%"
+                        "모든 스킬의 재사용 대기시간 : -2초(10초 이하는 10%감소, 5초 미만으로 감소 불가)" -> binding.tvOption1.text = "쿨감-2초"
+                        "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvOption1.text = "쿨감-1초"
+                        "아이템 드롭률 : +20%" -> binding.tvOption1.text = "드랍 20%"
+                        "메소 획득량 : +20%" -> binding.tvOption1.text ="메획 20%"
+                        "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvOption1.text ="렙당STR:+2"
+                        "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvOption1.text ="렙당DEX:+2"
+                        "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvOption1.text ="렙당INT:+2"
+                        "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvOption1.text ="렙당LUK:+2"
+                        "HP 회복 아이템 및 회복 스킬 효율 : +30%" -> binding.tvOption1.text = "기타"
+                        "4초 당 22의 MP 회복" -> binding.tvOption1.text = "기타 ♻️"
+                        "공격 시 10% 확률로 5레벨 중독효과 적용" -> binding.tvOption1.text = "기타 ♻️"
+                        "30% 확률로 받은 피해의 70%를 반사" -> binding.tvOption3.text = "기타 ♻️"
+                        "공격 시 5% 확률로 2레벨 기절효과 적용" -> binding.tvOption1.text = "기타 ♻️"
+                        "공격 시 3% 확률로 32의 HP 회복" -> binding.tvOption1.text = "기타 ♻️"
+                        "4초 당 24의 MP 회복" -> binding.tvOption1.text = "기타 ♻️"
 
-            var fp = binding.framePotential.visibility
+                        else -> binding.tvOption1.text = item?.potentialOption1
 
-            when (fp){
-               View.GONE -> binding.frameAddPotential.visibility = View.GONE
+                    }
+                }
+
             }
 
 
 
 
             //옵션2 조건처리
-            when(item?.potentialOption2.toString()) {
+            when(item?.potentialOption2) {
+
 
                 "크리티컬 데미지 : +8%" -> binding.tvOption2.text = "크뎀 8%"
                 "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption2.text ="쓸샾⭐"
@@ -115,16 +121,20 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvOption2.text ="렙당INT:+2"
                 "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvOption2.text ="렙당LUK:+2"
                 "HP 회복 아이템 및 회복 스킬 효율 : +30%" -> binding.tvOption2.text = "기타"
-                "4초 당 22의 MP 회복" -> binding.tvOption2.text = "기타"
-                "공격 시 10% 확률로 5레벨 중독효과 적용" -> binding.tvOption2.text = "기타"
+                "4초 당 22의 MP 회복" -> binding.tvOption2.text = "기타 ♻️"
+                "공격 시 10% 확률로 5레벨 중독효과 적용" -> binding.tvOption2.text = "기타 ♻️"
+                "공격 시 5% 확률로 2레벨 기절효과 적용" -> binding.tvOption2.text = "기타 ♻️"
                 "30% 확률로 받은 피해의 70%를 반사" -> binding.tvOption2.text = "기타 ♻️"
+                "공격 시 3% 확률로 32의 HP 회복" -> binding.tvOption2.text = "기타 ♻️"
+                "4초 당 24의 MP 회복" -> binding.tvOption2.text = "기타 ♻️"
+
                 else -> binding.tvOption2.text = item?.potentialOption2
 
             }
 
 
             //옵션3 조건처리
-            when(item?.potentialOption3.toString()) {
+            when(item?.potentialOption3) {
 
                 "크리티컬 데미지 : +8%" -> binding.tvOption3.text = "크뎀 8%"
                 "<쓸만한 샤프 아이즈> 스킬 사용 가능" -> binding.tvOption3.text ="<쓸샾>"
@@ -150,31 +160,47 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "공격 시 10% 확률로 5레벨 중독효과 적용" -> binding.tvOption3.text = "기타 ♻️"
                 "공격 시 5% 확률로 2레벨 기절효과 적용" -> binding.tvOption3.text = "기타 ♻️"
                 "30% 확률로 받은 피해의 70%를 반사" -> binding.tvOption3.text = "기타 ♻️"
+                "공격 시 3% 확률로 32의 HP 회복" -> binding.tvOption3.text = "기타 ♻️"
+                "4초 당 24의 MP 회복" -> binding.tvOption3.text = "기타 ♻️"
 
                 else -> binding.tvOption3.text = item?.potentialOption3
             }
             //에디1 조건처리
-            when(item?.additionalPotentialOption1.toString()) {
+            when(item?.additionalPotentialOption1) {
 
-                "크리티컬 데미지 : +3%" -> binding.tvAddTvOption1.text = "크뎀 3%"
-                "크리티컬 데미지 : +1%" -> binding.tvAddTvOption1.text = "크뎀 1%"
-                "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption1.text = "보공18%"
-                "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption1.text = "보공12%"
-                "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvAddTvOption1.text = "쿨감-1초"
-                "아이템 드롭률 : +5%" -> binding.tvAddTvOption1.text = "드랍 5%"
-                "메소 획득량 : +5%" -> binding.tvAddTvOption1.text ="메획 5%"
-                "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvAddTvOption1.text ="렙당STR:+2"
-                "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvAddTvOption1.text ="렙당DEX:+2"
-                "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvAddTvOption1.text ="렙당INT:+2"
-                "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvAddTvOption1.text ="렙당LUK:+2"
-                "캐릭터 기준 9레벨 당 STR : +1" -> binding.tvAddTvOption1.text ="렙당STR:+1"
-                "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption1.text ="렙당DEX:+1"
-                "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption1.text ="렙당INT:+1"
-                "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption1.text ="렙당LUK:+1"
-                else -> binding.tvAddTvOption1.text = item?.additionalPotentialOption1
+                null -> binding.frameAddPotential.visibility = View.GONE
+                else -> {binding.frameAddPotential.visibility = View.VISIBLE
+
+                    when (item?.additionalPotentialOption1){
+                        "크리티컬 데미지 : +3%" -> binding.tvAddTvOption1.text = "크뎀 3%"
+                        "크리티컬 데미지 : +1%" -> binding.tvAddTvOption1.text = "크뎀 1%"
+                        "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption1.text = "보공18%"
+                        "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption1.text = "보공12%"
+                        "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvAddTvOption1.text = "쿨감-1초"
+                        "아이템 드롭률 : +5%" -> binding.tvAddTvOption1.text = "드랍 5%"
+                        "메소 획득량 : +5%" -> binding.tvAddTvOption1.text ="메획 5%"
+                        "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvAddTvOption1.text ="렙당STR:+2"
+                        "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvAddTvOption1.text ="렙당DEX:+2"
+                        "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvAddTvOption1.text ="렙당INT:+2"
+                        "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvAddTvOption1.text ="렙당LUK:+2"
+                        "캐릭터 기준 9레벨 당 STR : +1" -> binding.tvAddTvOption1.text ="렙당STR:+1"
+                        "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption1.text ="렙당DEX:+1"
+                        "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption1.text ="렙당INT:+1"
+                        "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption1.text ="렙당LUK:+1"
+                        "공격 시 15% 확률로 85의 HP 회복" -> binding.tvAddTvOption1.text = "기타 ♻️"
+
+                        else -> binding.tvAddTvOption1.text = item?.additionalPotentialOption1
+
+
+                    }
+                }
+
+
             }
             //에디2 조건처리
-            when(item?.additionalPotentialOption2.toString()) {
+            when(item?.additionalPotentialOption2) {
+
+
                 "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption2.text = "보공18%"
                 "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption2.text = "보공12%"
                 "크리티컬 데미지 : +3%" -> binding.tvAddTvOption2.text = "크뎀 3%"
@@ -190,10 +216,14 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption2.text ="렙당DEX:+1"
                 "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption2.text ="렙당INT:+1"
                 "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption2.text ="렙당LUK:+1"
+                "공격 시 15% 확률로 85의 HP 회복" -> binding.tvAddTvOption2.text = "기타 ♻️"
+
                 else -> binding.tvAddTvOption2.text = item?.additionalPotentialOption2
             }
             //에디3 조건처리
-            when(item?.additionalPotentialOption3.toString()) {
+            when(item?.additionalPotentialOption3) {
+
+
                 "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption3.text = "보공18%"
                 "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption3.text = "보공12%"
                 "크리티컬 데미지 : +3%" -> binding.tvAddTvOption3.text = "크뎀 3%"
@@ -209,13 +239,10 @@ class SecondFragmentAdapter(val items: MutableList<Equipment.ItemEquipment?>) :
                 "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption3.text ="렙당DEX:+1"
                 "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption3.text ="렙당INT:+1"
                 "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption3.text ="렙당LUK:+1"
+                "공격 시 15% 확률로 85의 HP 회복" -> binding.tvAddTvOption3.text = "기타 ♻️"
+
                 else -> binding.tvAddTvOption3.text = item?.additionalPotentialOption3
             }
-
-//            when(item?.potentialOption1.toString() && item?.potentialOption1&& item?.potentialOption1){
-//
-//                "크뎀8%" -> binding.tvOption1.text = "씨발 크크크다"
-//            }
         }
     }
 }

--- a/app/src/main/java/com/android/maplemate/UI/SecondFragment.kt
+++ b/app/src/main/java/com/android/maplemate/UI/SecondFragment.kt
@@ -2,6 +2,7 @@ package com.android.maplemate.UI
 
 import android.content.Context
 import android.os.Bundle
+import android.os.Handler
 import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -17,6 +18,10 @@ import com.android.maplemate.Data.Equipment
 import com.android.maplemate.Data.MapleData
 import com.android.maplemate.ViewModel.SecondFragmentViewModel
 import com.android.maplemate.databinding.FragmentSecondBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 
 class SecondFragment : Fragment() {
@@ -104,9 +109,10 @@ class SecondFragment : Fragment() {
         }
         viewModel.EquipmentList.observe(viewLifecycleOwner) { newDataList ->
             // 리싸이클러뷰 데이터 업데이트
-            adapter.submitList(newDataList)
-            Log.d("RecyclerView", "Data List Size (Adapter): ${adapter.itemCount}")
-            Log.d("RecyclerView", "submitList 되고있니?:${adapter.submitList(newDataList)}")
+            Handler().postDelayed({
+                adapter.submitList(newDataList)
+            }, 500) // 1000밀리초(1초)의 딜레이
+
 
         }
     }

--- a/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModel.kt
+++ b/app/src/main/java/com/android/maplemate/ViewModel/SecondFragmentViewModel.kt
@@ -154,6 +154,7 @@ class SecondFragmentViewModel : ViewModel() {
                             response: Response<Equipment>
                         ) {
                             handleEquipmentResponse(response)
+
                         }
 
                         override fun onFailure(call: Call<Equipment>, t: Throwable) {
@@ -194,20 +195,18 @@ class SecondFragmentViewModel : ViewModel() {
         if (response.isSuccessful) {
             val data = response.body()?.itemEquipment
 
+            Log.d("장비", "${data?.joinToString("\n") { it?.itemName ?: "null" }}")
+            Log.d("장비", "윗잠1:${data?.joinToString("\n") { it?.potentialOption1 ?: "null" }}")
+
             if (!data.isNullOrEmpty()) {
 
                 addDataItem(data)
-
             }
         }
     }
 
     fun addDataItem(newItem: List<Equipment.ItemEquipment?>) {
 
-        if (!newItem.isNullOrEmpty()) {
-
             _EquipmentList.value = newItem
-
-        }
     }
 }


### PR DESCRIPTION
```kotlin
[기존코드] 
            when(item?.additionalPotentialOption1) {

                null -> binding.frameAddPotential.visibility = View.GONE
             
                        "크리티컬 데미지 : +3%" -> binding.tvAddTvOption1.text = "크뎀 3%"
                        "크리티컬 데미지 : +1%" -> binding.tvAddTvOption1.text = "크뎀 1%"
                        "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption1.text = "보공18%"
                        "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption1.text = "보공12%"
                        "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvAddTvOption1.text = "쿨감-1초"
                        "아이템 드롭률 : +5%" -> binding.tvAddTvOption1.text = "드랍 5%"
                        "메소 획득량 : +5%" -> binding.tvAddTvOption1.text ="메획 5%"
                        "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvAddTvOption1.text ="렙당STR:+2"
                        "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvAddTvOption1.text ="렙당DEX:+2"
                        "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvAddTvOption1.text ="렙당INT:+2"
                        "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvAddTvOption1.text ="렙당LUK:+2"
                        "캐릭터 기준 9레벨 당 STR : +1" -> binding.tvAddTvOption1.text ="렙당STR:+1"
                        "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption1.text ="렙당DEX:+1"
                        "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption1.text ="렙당INT:+1"
                        "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption1.text ="렙당LUK:+1"
                        "공격 시 15% 확률로 85의 HP 회복" -> binding.tvAddTvOption1.text = "기타 ♻️"

                        else -> binding.tvAddTvOption1.text = item?.additionalPotentialOption1

            }
```
발생한문제. 트와일라이트마크 아이템의 잠재옵션 1번이 있음에도 불구하고 해당 옵션의 프레임이 사라짐.
추정원인: 조건 로직 상. 데이터리스트중 하나라도 null이 있을 경우에 View가 GONE 처리가될것이다.
해결방법: 1번 옵션에 데이터가 null이 들어올 경우 GONE 처리하고, 아닐시에 VISIBLE 처리하는것으로 해결.

해당조건상 모든 리스트의 1번 옵션이 null 이면 조건이 발동하게 되는데, 사라지는것은 모든 리스트의 옵션이 사라지는게 아니라, 랜덤하게
사라지는걸 확인할 수 있었습니다. 왜 이러한 문제가 생기는지에 대해서는 아직 알 수 없었습니다.

<p align="center">
    <img src="https://github.com/Retudy/Maplemate/assets/129308578/f7c11ee4-0d47-44db-a52f-fec180729694" alt="이미지 설명">
</p>



```kotlin
[변경후 코드] 
            when(item?.additionalPotentialOption1) {

                null -> binding.frameAddPotential.visibility = View.GONE
                else -> {binding.frameAddPotential.visibility = View.VISIBLE

                    when (item?.additionalPotentialOption1){
                        "크리티컬 데미지 : +3%" -> binding.tvAddTvOption1.text = "크뎀 3%"
                        "크리티컬 데미지 : +1%" -> binding.tvAddTvOption1.text = "크뎀 1%"
                        "보스 몬스터 공격 시 데미지 : +18%" -> binding.tvAddTvOption1.text = "보공18%"
                        "보스 몬스터 공격 시 데미지 : +12%" -> binding.tvAddTvOption1.text = "보공12%"
                        "모든 스킬의 재사용 대기시간 : -1초(10초 이하는 5%감소, 5초 미만으로 감소 불가)" -> binding.tvAddTvOption1.text = "쿨감-1초"
                        "아이템 드롭률 : +5%" -> binding.tvAddTvOption1.text = "드랍 5%"
                        "메소 획득량 : +5%" -> binding.tvAddTvOption1.text ="메획 5%"
                        "캐릭터 기준 9레벨 당 STR : +2" -> binding.tvAddTvOption1.text ="렙당STR:+2"
                        "캐릭터 기준 9레벨 당 DEX : +2" -> binding.tvAddTvOption1.text ="렙당DEX:+2"
                        "캐릭터 기준 9레벨 당 INT : +2" -> binding.tvAddTvOption1.text ="렙당INT:+2"
                        "캐릭터 기준 9레벨 당 LUK : +2" -> binding.tvAddTvOption1.text ="렙당LUK:+2"
                        "캐릭터 기준 9레벨 당 STR : +1" -> binding.tvAddTvOption1.text ="렙당STR:+1"
                        "캐릭터 기준 9레벨 당 DEX : +1" -> binding.tvAddTvOption1.text ="렙당DEX:+1"
                        "캐릭터 기준 9레벨 당 INT : +1" -> binding.tvAddTvOption1.text ="렙당INT:+1"
                        "캐릭터 기준 9레벨 당 LUK : +1" -> binding.tvAddTvOption1.text ="렙당LUK:+1"
                        "공격 시 15% 확률로 85의 HP 회복" -> binding.tvAddTvOption1.text = "기타 ♻️"

                        else -> binding.tvAddTvOption1.text = item?.additionalPotentialOption1

                    }
                }
            }
```
변경후 정상으로 작동되는것을 확인.